### PR TITLE
Resolving circular dependency in DAG

### DIFF
--- a/metaflow/plugins/cards/ui/src/components/dag/constants.svelte
+++ b/metaflow/plugins/cards/ui/src/components/dag/constants.svelte
@@ -1,0 +1,3 @@
+<script context="module">
+  export const currentStepContext = "currentStep";
+</script>

--- a/metaflow/plugins/cards/ui/src/components/dag/dag.svelte
+++ b/metaflow/plugins/cards/ui/src/components/dag/dag.svelte
@@ -1,8 +1,4 @@
 <!-- Draws a DAG (Directed Acyclic Graph) based on the input steps -->
-<script context="module">
-  export const currentStepContext = "currentStep";
-</script>
-
 <script lang="ts">
   import "./dag.css";
   import Connectors from "./connectors.svelte";
@@ -11,6 +7,7 @@
   import type { Boxes, DagComponent } from "../../types";
   import { cardData } from "../../store";
   import { getStepNameFromPathSpec } from "../../utils";
+  import { currentStepContext } from "./constants.svelte";
 
   export let componentData: DagComponent;
 

--- a/metaflow/plugins/cards/ui/src/components/dag/step.svelte
+++ b/metaflow/plugins/cards/ui/src/components/dag/step.svelte
@@ -3,7 +3,7 @@
   import type { DagStep } from "../../types";
   import { getContext, onMount } from "svelte";
   import { isOverflown } from "../../utils";
-  import { currentStepContext } from "./dag.svelte";
+  import { currentStepContext } from "./constants.svelte";
 
   export let name: string;
   export let step: DagStep;


### PR DESCRIPTION
When running `yarn build`, changing from 

```
(!) Circular dependencies
src/components/dag/dag.svelte -> src/components/dag/step-wrapper.svelte -> src/components/dag/step.svelte -> src/components/dag/dag.svelte
src/components/card-component-renderer.svelte -> src/components/page.svelte -> src/components/card-component-renderer.svelte
src/components/card-component-renderer.svelte -> src/components/section.svelte -> src/components/card-component-renderer.svelte
```

to

```
(!) Circular dependencies
src/components/card-component-renderer.svelte -> src/components/page.svelte -> src/components/card-component-renderer.svelte
src/components/card-component-renderer.svelte -> src/components/section.svelte -> src/components/card-component-renderer.svelte
```

by creating a new file `dag.constants.svelte` and putting a shared context name string in there so that it can be accessed by the components that use it.