### PR TITLE
`MetaflowCardComponent`s in Userland

### DIFF
--- a/metaflow/plugins/cards/card_modules/basic.py
+++ b/metaflow/plugins/cards/card_modules/basic.py
@@ -240,6 +240,18 @@ class PageComponent(DefaultComponent):
         return datadict
 
 
+class ErrorComponent(MetaflowCardComponent):
+    def __init__(self, headline, error_message):
+        self._headline = headline
+        self._error_message = error_message
+
+    def render(self):
+        return SectionComponent(
+            title=self._headline,
+            contents=[LogComponent(data=self._error_message)],
+        ).render()
+
+
 class ArtifactsComponent(DefaultComponent):
     type = "artifacts"
 

--- a/metaflow/plugins/cards/component_serializer.py
+++ b/metaflow/plugins/cards/component_serializer.py
@@ -1,0 +1,77 @@
+from .card_modules import MetaflowCardComponent
+from .card_modules.basic import ErrorComponent
+
+
+class SerializationErrorComponent(ErrorComponent):
+    def __init__(self, component_name, error_message):
+        headline = "Component %s [RENDER FAIL]" % component_name
+        super().__init__(headline, error_message)
+
+
+class CardComponentCollector:
+    """
+    This class helps collect `MetaflowCardComponent`s during runtime execution
+
+    ### Usage with `current`
+    `current.cards` is of type `CardComponentCollector`
+
+    ```python
+    # Add to single card
+    current.cards['default'].append(TableComponent())
+    # Add to all cards
+    current.cards.append(TableComponent())
+    ```
+    ### Some Gotcha's
+
+    If a decorator has the same type for multiple steps then we need to gracefully exit or
+    ignore that redundant card decorator.
+    """
+
+    def __init__(self, types=[]):
+        self._cards = {_type: [] for _type in types}
+
+    def __getitem__(self, key):
+        return self._cards.get(key, None)
+
+    def __setitem__(self, key, value):
+        self._cards[key] = value
+
+    def _add_type(self, card_type):
+        self._cards[card_type] = []
+
+    def append(self, component):
+        for ct in self._cards:
+            self._cards[ct].append(component)
+
+    def extend(self, components):
+        for ct in self._cards:
+            self._cards[ct].extend(components)
+
+    def serialize_components(self, component_type):
+        import traceback
+
+        serialized_components = []
+        if component_type not in self._cards:
+            return []
+        for component in self._cards[component_type]:
+            if not issubclass(type(component), MetaflowCardComponent):
+                continue
+            try:
+                rendered_obj = component.render()
+                assert type(rendered_obj) == str or type(rendered_obj) == dict
+                serialized_components.append(rendered_obj)
+            except AssertionError:
+                serialized_components.append(
+                    SerializationErrorComponent(
+                        component.__class__.__name__,
+                        "Component render didn't return a string",
+                    ).render()
+                )
+            except:
+                error_str = traceback.format_exc()
+                serialized_components.append(
+                    SerializationErrorComponent(
+                        component.__class__.__name__, error_str
+                    ).render()
+                )
+        return serialized_components


### PR DESCRIPTION
# Usage of `MetaflowCardComponent`s in Userland
**Previous PR #20** 
## What does this PR address
This PR introduces a strawman proposal of using `MetaflowCardComponent` in `@step` code. The `MetaflowCardComponent`'s are subcomponents of `MetaflowCard`s. These subcomponents get introduced into the card when the card gets compiled (currently at `task_finished`). This PR introduces an attribute to the `current` object named `current.cards` to collect information that needs to go into different cards. As this PR builds upon #20 , there be many `@card` decorators added to a `@step`. This PR adds logic to add the right component to the desired card.

## What are the Changes. 
1. Add an attribute to `current` called `cards`. `cards` is a dictionary-like object where each key's value is a `list` of  `MetaflowCardComponent`. 
2. Upon addition of components to `current.cards` we pass these components to the card process by writing them down to a tempfile and them passing the path to the file in `--component-file`; 
3.  As cards can support multiple decorators, we can access individual cards via `currrent.cards[<card_type>]`. 


## API Specification

### Usage in `@step` code 
```python
from metaflow import FlowSpec,step,card
class Flow(FlowSpec):
	
	@card(type='dbt_card')
	@card(type='monitoring_card')
	@card(type='model_score_card')
	@step
	def start(self):
		from metaflow import current 
		import numpy as np
		from metaflow.cards import Artifact,TitleComponent,BarChartComponent
		self.x = 100
		current.cards.append(TitleComponent("This Heading will be common in all cards"))
		current.cards['monitoring_card'].append(Artifact(self.x)) # current.cards is a `CardComponentCollector` object
		self.next(self.end)
		
	@step
	def end(self):
		pass
```
### Usage with `current`

`current.cards` is of type `CardComponentCollector`
```python
# Add to `default` card
current.cards['default'].append(TableComponent())
# Add to all cards
current.cards.append(TableComponent())
```

## Open Questions 
1. When we are allowed to have multiple `@card` decorators we can also face a situation given by the below snippet. In this situation, it is ambiguous to figure out which card the user is referring to when they invoke `current.cards['default']` as both card are of default type
  ```python
    @card(type='default')
    @card(type='default',options=dict(only_repr=False))
    @step
    def start(self):
  ```
  
2. What is the maximum number of `@card` decorators that can be stacked together. 

## Some Proposal to Open Questions. 

### Disambiguating multiple decorators of same type

#### Solution 1 
- Keep a strict check to allow only one `type` of MetaflowCard per `@step`
#### Solution 2
- introduce `id` property and force user to set `id` property when multiple decorators of same `type` are stacked.  
- `id` will be unique per `@step`. 
- Access to information happens like the follows
  ```python
    @card(id='profit_card')
    @card(id='loss_card',)
    @step
    def start(self):
      from metaflow import currrent
      from metaflow.cards import Table
      # Adds component to `profit_card` card 
      current.cards['profit_card'].append(Table(..))
      # Adds to all `default` cards attached to `@step`
      current.cards['default'].append(Table(..))
  ```
#### Solution 3
- introduce a private property named `index` and change insertion via `current.cards` to the following. 
  ```python
      @card
      @card
      @step
      def start(self):
        from metaflow import currrent
        from metaflow.cards import Table
        # Adds component to card at `0`th decorator from the top 
        current.cards[0].append(Table(..))
        # Adds to all `default` cards attached to `@step`
        current.cards['default'].append(Table(..))
    ```
- the `index` will help map the card present at decorator index 

## Next PRs
- Adding `id` to `@card`
- Polishing user exposed `MetaflowCardComponent`s
