### PR TITLE
`Section` Removal 

### DIFF
--- a/metaflow/cards.py
+++ b/metaflow/cards.py
@@ -5,7 +5,6 @@ from metaflow.plugins.cards.card_modules.components import (
     Table,
     Image,
     Error,
-    Section,
     Markdown,
 )
 from metaflow.plugins.cards.card_modules.basic import (

--- a/metaflow/plugins/cards/card_modules/basic.py
+++ b/metaflow/plugins/cards/card_modules/basic.py
@@ -40,6 +40,11 @@ def read_file(path):
 
 
 class DefaultComponent(MetaflowCardComponent):
+    """
+    The `DefaultCard` and the `BlankCard` use a JS framework that build the HTML dynamically from JSON. The `DefaultComponent` is the base component that helps build the JSON when `render` is called.
+
+    The underlying JS framewok consists of various types of objects. These can be found in: "metaflow/plugins/cards/ui/types.ts". The `type` attribute in a `DefaultComponent` corresponds to the type of component in the Javascript framework.
+    """
 
     type = None
 
@@ -265,9 +270,8 @@ class ErrorComponent(MetaflowCardComponent):
         self._error_message = error_message
 
     def render(self):
-        return SectionComponent(
-            title=self._headline,
-            contents=[LogComponent(data=self._error_message)],
+        return LogComponent(
+            data="%s\n\n%s" % (self._headline, self._error_message)
         ).render()
 
 

--- a/metaflow/plugins/cards/card_modules/components.py
+++ b/metaflow/plugins/cards/card_modules/components.py
@@ -20,11 +20,12 @@ class Artifact(UserComponent):
     """
     This class helps visualize any variable on the `MetaflowCard`.
     The variable will be truncated using `reprlib.Repr.repr()`.
-    Usage :
+
+    ### Usage :
     ```python
     @card
     @step
-    def my_step(self)
+    def my_step(self):
         from metaflow.cards import Artifact
         from metaflow import current
         x = dict(a=2,b=2..)
@@ -48,6 +49,52 @@ class Artifact(UserComponent):
 
 
 class Table(UserComponent):
+    """
+    This class helps visualize information in the form of a table in a `MetaflowCard`.
+    `Table` can take other `MetaflowCardComponent`s like `Artifact`, `Image`, `Markdown` and `Error` as sub elements.
+
+    ### Parameters
+    - `data` (List[List[Any]]) : The data to see in the table. Input is a 2d list that contains native types or `MetaflowCardComponent`s like `Artifact`, `Image`, `Markdown` and `Error`. Doesn't play friendly with `dict` as a sub-element. If passing a `dict`, pass it via `Artifact`. Example : `Table([[Artifact(my_dictionary)]])`. If a non serializable object is passed as a sub-element then the table cell on the `MetaflowCard` will show up as `<object>`. columns.  Defaults to [[]].
+    - `headers` (List[str]) : The names of the columns.  Defaults to [].
+
+    ### Usage with other components:
+    ```python
+    @card
+    @step
+    def my_step(self):
+        from metaflow.cards import Table, Artifact
+        from metaflow import current
+        x = dict(a=2,b=2..)
+        y = dict(b=3,c=2..)
+        # Can take other components as arguments
+        current.card.append(
+            Table([[
+                Artifact(x), # Adds a name to the artifact
+                Artifact(y), # Adds a name to the artifact
+            ]])
+        current.card.append(Artifact(x,'my artifact name'))
+    ```
+    ### Usage with dataframes:
+    ```python
+    @card
+    @step
+    def my_step(self):
+        from metaflow.cards import Table
+        from metaflow import current
+        # Can be created from a dataframe
+        import pandas as pd
+        import numpy as np
+        current.card.append(
+            Table.from_dataframe(
+                pandas.DataFrame(
+                    np.random.randint(0, 100, size=(15, 4)),
+                    columns=list("ABCD"),
+                )
+            )
+        )
+    ```
+    """
+
     def __init__(self, data=[[]], headers=[]):
         header_bool, data_bool = TableComponent.validate(headers, data)
         self._headers = []
@@ -99,6 +146,64 @@ class Table(UserComponent):
 
 
 class Image(UserComponent):
+    """
+    This class helps visualize an image in a `MetaflowCard`. `Image`s can be created direcly from `bytes` or `PIL.Image`s or Matplotib figures.
+
+    ### Parameters
+    - `src` (bytes) : The image source in `bytes`.
+    - `label` (str) : Label to the image show on the `MetaflowCard`.
+
+    ### Usage
+    ```python
+    @card
+    @step
+    def my_step(self):
+        from metaflow.cards import Image
+        from metaflow import current
+        import requests
+        current.card.append(
+            Image(
+                requests.get("https://www.gif-vif.com/hacker-cat.gif").content,
+                "Image From Bytes",
+            ),
+        )
+    ```
+
+    #### `Image.from_matplotlib` :
+    ```python
+    @card
+    @step
+    def my_step(self):
+        from metaflow.cards import Image
+        from metaflow import current
+        import pandas as pd
+        import numpy as np
+        current.card.append(
+            Image.from_matplotlib(
+                pandas.DataFrame(
+                    np.random.randint(0, 100, size=(15, 4)),
+                    columns=list("ABCD"),
+                ).plot()
+            )
+        )
+    ```
+    #### `Image.from_pil_image` :
+    ```python
+    @card
+    @step
+    def my_step(self):
+        from metaflow.cards import Image
+        from metaflow import current
+        from PIL import Image as PILImage
+        current.card.append(
+            Image.from_pil_image(
+                PILImage.fromarray(np.random.randn(1024, 768), "RGB"),
+                "From PIL Image",
+            ),
+        )
+    ```
+    """
+
     @staticmethod
     def render_fail_headline(msg):
         return "[IMAGE_RENDER FAIL]: %s" % msg
@@ -239,6 +344,31 @@ class Image(UserComponent):
 
 
 class Error(UserComponent):
+    """
+    This class helps visualize Error's on the `MetaflowCard`. It can help catch and print stack traces to errors that happen in `@step` code.
+
+    ### Parameters
+    - `exception` (Exception) : The `Exception` to visualize. This value will be `repr`'d before passed down to `MetaflowCard`
+    - `title` (str) : The title that will appear over the visualized  `Exception`.
+
+    ### Usage
+    ```python
+    @card
+    @step
+    def my_step(self):
+        from metaflow.cards import Error
+        from metaflow import current
+        try:
+            ...
+            ...
+        except Exception as e:
+            current.card.append(
+                Error(e,"Something misbehaved")
+            )
+        ...
+    ```
+    """
+
     def __init__(self, exception, title=None):
         self._exception = exception
         self._title = title
@@ -249,6 +379,27 @@ class Error(UserComponent):
 
 
 class Markdown(UserComponent):
+    """
+    This class helps visualize Markdown on the `MetaflowCard`
+
+    ### Parameters
+    - `text` (str) : A markdown string
+
+    ### Usage
+    ```python
+    @card
+    @step
+    def my_step(self):
+        from metaflow.cards import Markdown
+        from metaflow import current
+        current.card.append(
+            Markdown("# This is a header appended from @step code")
+        )
+        ...
+    ```
+
+    """
+
     def __init__(self, text=None):
         self._text = text
 

--- a/metaflow/plugins/cards/card_modules/renderer_tools.py
+++ b/metaflow/plugins/cards/card_modules/renderer_tools.py
@@ -1,0 +1,49 @@
+import traceback
+import json
+
+# from .card import MetaflowCardComponent
+from .basic import SerializationErrorComponent
+
+
+def _render_component_safely(
+    component, render_func, *args, return_error_component=True, **kwargs
+):
+    rendered_obj = None
+    try:
+        rendered_obj = render_func(component, *args, **kwargs)
+    except:
+        if not return_error_component:
+            return None
+        error_str = traceback.format_exc()
+        rendered_obj = SerializationErrorComponent(
+            component.__class__.__name__, error_str
+        ).render()
+    else:
+        if not (type(rendered_obj) == str or type(rendered_obj) == dict):
+            rendered_obj = SerializationErrorComponent(
+                component.__class__.__name__,
+                "Component render didn't return a `string` or `dict`",
+            ).render()
+        else:
+            try:  # check if rendered object is json serializable.
+                json.dumps(rendered_obj)
+            except (TypeError, OverflowError) as e:
+                rendered_obj = SerializationErrorComponent(
+                    component.__class__.__name__,
+                    "Rendered Component cannot be JSON serialized. \n\n %s" % str(e),
+                ).render()
+    return rendered_obj
+
+
+def render_safely(func):
+    """
+    This is a decorator that can be added to any `MetaflowCardComponent.render`
+    The goal is to render sub components safely and ensure that they are JSON serializable.
+    """
+    # expects a renderer func
+    def ret_func(self, *args, **kwargs):
+        return _render_component_safely(
+            self, func, *args, return_error_component=True, **kwargs
+        )
+
+    return ret_func

--- a/metaflow/plugins/cards/component_serializer.py
+++ b/metaflow/plugins/cards/component_serializer.py
@@ -1,5 +1,6 @@
 from .card_modules import MetaflowCardComponent
-from .card_modules.basic import ErrorComponent, SerializationErrorComponent
+from .card_modules.basic import ErrorComponent, SectionComponent
+from .card_modules.components import UserComponent
 import random
 import string
 import json
@@ -305,37 +306,40 @@ class CardComponentCollector:
         self._cards[self._default_editable_card].extend(components)
 
     def _serialize_components(self, card_uuid):
+        """
+        This method renders components present in a card to strings/json.
+        Components exposed by metaflow ensure that they render safely. If components
+        don't render safely then we don't add them to the final list of serialized functions
+        """
         import traceback
 
         serialized_components = []
         if card_uuid not in self._cards:
             return []
+        has_user_components = any(
+            [
+                issubclass(type(component), UserComponent)
+                for component in self._cards[card_uuid]
+            ]
+        )
         for component in self._cards[card_uuid]:
             if not issubclass(type(component), MetaflowCardComponent):
                 continue
             try:
                 rendered_obj = component.render()
             except:
-                error_str = traceback.format_exc()
-                serialized_components.append(
-                    SerializationErrorComponent(
-                        component.__class__.__name__, error_str
-                    ).render()
-                )
+                continue
             else:
                 if not (type(rendered_obj) == str or type(rendered_obj) == dict):
-                    rendered_obj = SerializationErrorComponent(
-                        component.__class__.__name__,
-                        "Component render didn't return a `string` or `dict`",
-                    ).render()
+                    continue
                 else:
                     try:  # check if rendered object is json serializable.
                         json.dumps(rendered_obj)
                     except (TypeError, OverflowError) as e:
-                        rendered_obj = SerializationErrorComponent(
-                            component.__class__.__name__,
-                            "Rendered Component cannot be JSON serialized. \n\n %s"
-                            % str(e),
-                        ).render()
+                        continue
                 serialized_components.append(rendered_obj)
+        if has_user_components and len(serialized_components) > 0:
+            serialized_components = [
+                SectionComponent(contents=serialized_components).render()
+            ]
         return serialized_components

--- a/metaflow/plugins/cards/component_serializer.py
+++ b/metaflow/plugins/cards/component_serializer.py
@@ -311,8 +311,6 @@ class CardComponentCollector:
         Components exposed by metaflow ensure that they render safely. If components
         don't render safely then we don't add them to the final list of serialized functions
         """
-        import traceback
-
         serialized_components = []
         if card_uuid not in self._cards:
             return []

--- a/metaflow/plugins/cards/component_serializer.py
+++ b/metaflow/plugins/cards/component_serializer.py
@@ -333,10 +333,14 @@ class CardComponentCollector:
                 if not (type(rendered_obj) == str or type(rendered_obj) == dict):
                     continue
                 else:
-                    try:  # check if rendered object is json serializable.
-                        json.dumps(rendered_obj)
-                    except (TypeError, OverflowError) as e:
-                        continue
+                    # Since `UserComponent`s are safely_rendered using render_tools.py
+                    # we don't need to check JSON serialization as @render_tools.render_safely
+                    # decorator ensures this check so there is no need to re-serialize
+                    if not issubclass(type(component), UserComponent):
+                        try:  # check if rendered object is json serializable.
+                            json.dumps(rendered_obj)
+                        except (TypeError, OverflowError) as e:
+                            continue
                 serialized_components.append(rendered_obj)
         if has_user_components and len(serialized_components) > 0:
             serialized_components = [


### PR DESCRIPTION
- Removed `Section` component from `metaflow.cards`
- Making user-facing component inherent to `UserComponent` which in turn inherits `MetaflowCardComponent`
- Wrap all `UserComponents` inside a section after rendering everything per card
- created a `render_safely` decorator to ensure fail-safe render of `UserComponent`s
- removed code from component serializer which used internal components
- Refactored some components that return render
- Added docstrings to all components.