### PR TITLE
Airflow Sensor Support

### DIFF
--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -152,8 +152,15 @@ _merge_lists(METADATA_PROVIDERS, _ext_plugins["METADATA_PROVIDERS"], "TYPE")
 from .conda.conda_flow_decorator import CondaFlowDecorator
 from .aws.step_functions.schedule_decorator import ScheduleDecorator
 from .project_decorator import ProjectDecorator
+from .trigger import TriggerDecorator, TriggerOnFinishDecorator
 
-FLOW_DECORATORS = [CondaFlowDecorator, ScheduleDecorator, ProjectDecorator]
+FLOW_DECORATORS = [
+    TriggerOnFinishDecorator,
+    TriggerDecorator,
+    CondaFlowDecorator,
+    ScheduleDecorator,
+    ProjectDecorator,
+]
 _merge_lists(FLOW_DECORATORS, _ext_plugins["FLOW_DECORATORS"], "name")
 
 # Cards

--- a/metaflow/plugins/airflow/airflow_decorator.py
+++ b/metaflow/plugins/airflow/airflow_decorator.py
@@ -4,7 +4,8 @@ import time
 
 from metaflow.decorators import StepDecorator
 from metaflow.metadata import MetaDatum
-from .airflow_utils import TASK_ID_XCOM_KEY
+from .airflow_utils import TASK_ID_XCOM_KEY, TASK_PATHSPEC_KEY
+from metaflow import current
 
 
 K8S_XCOM_DIR_PATH = "/airflow/xcom"
@@ -46,6 +47,7 @@ class AirflowInternalDecorator(StepDecorator):
         meta = {}
         meta["airflow-dag-run-id"] = os.environ["METAFLOW_AIRFLOW_DAG_RUN_ID"]
         meta["airflow-job-id"] = os.environ["METAFLOW_AIRFLOW_JOB_ID"]
+        meta["airflow-dag-id"] = os.environ["METAFLOW_AIRFLOW_DAG_ID"]
         entries = [
             MetaDatum(
                 field=k, value=v, type=k, tags=["attempt_id:{0}".format(retry_count)]
@@ -57,5 +59,6 @@ class AirflowInternalDecorator(StepDecorator):
         push_xcom_values(
             {
                 TASK_ID_XCOM_KEY: os.environ["METAFLOW_AIRFLOW_TASK_ID"],
+                TASK_PATHSPEC_KEY: current.pathspec,
             }
         )

--- a/metaflow/plugins/trigger.py
+++ b/metaflow/plugins/trigger.py
@@ -1,0 +1,47 @@
+import os
+from metaflow.decorators import FlowDecorator
+
+
+class TriggerDecorator(FlowDecorator):
+    name = "trigger"
+    defaults = {"event": None}
+
+    def __init__(self, *args, statically_defined=False, **kwargs):
+        self._kwargs = kwargs
+        _defaults = {
+            k: self._kwargs[k] if k in self._kwargs else v
+            for k, v in self.defaults.items()
+        }
+        super().__init__(
+            *args,
+            attributes=_defaults,
+            statically_defined=statically_defined,
+        )
+        self.attributes.update(self._kwargs["attributes"])
+
+
+class TriggerOnFinishDecorator(TriggerDecorator):
+    name = "trigger_on_finish"
+    defaults = {
+        "flow": None,
+        "branch": None,
+    }
+
+    def flow_init(
+        self, flow, graph, environment, flow_datastore, metadata, logger, echo, options
+    ):
+        from metaflow import Run
+
+        flow.input_flow = None
+        tags = []
+        if "METAFLOW_UPSTREAM_EVENT_TRIGGER_PATHSPEC" in os.environ:
+            pth = "/".join(
+                os.environ["METAFLOW_UPSTREAM_EVENT_TRIGGER_PATHSPEC"].split("/")[:2]
+            )
+            flow.input_flow = Run(pth)
+            tags.append("parent_run_pathspec:%s" % pth)
+        if "METAFLOW_EVENTS_BACKEND" in os.environ:
+            backend = os.environ["METAFLOW_EVENTS_BACKEND"]
+            tags.append("events_backend:%s" % backend)
+        if len(tags) > 0:
+            metadata.add_sticky_tags(sys_tags=tags)


### PR DESCRIPTION
# Changes 
- [x] Added `@trigger_on_finish` decorator. Decorator maps to `ExternalTaskSensor`.
- [x] Fix id creation for run-id / task-id. Add uniqueness guarantees based for triggering multiple.
- [ ] Add `@trigger` decorator support for `S3KeySensor` / `SqlSensor` / `PythonSensor`
- [ ] Support `@project`

# Todos
- [ ] Test Test Test ( Many ways . Even with local )
- [ ] Check if a default pathspec argument is possible for `@trigger_on_finish`. This ensures a Run object can have a default. 
- [ ] Test with `@project`
- [ ] Support other sensors

